### PR TITLE
Add API documentation + browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ OSS Attribution Builder is a website that helps teams create attribution documen
 1. Install [Docker](https://www.docker.com/)
 2. Clone this repository
 3. Run `docker-compose up`
-4. Visit http://localhost:8000/
+4. Visit http://localhost:2424/
    * The demo uses HTTP basic auth. Enter any username and password. Use `admin` to test out admin functionality.
 
 ## Using the Website
@@ -86,7 +86,7 @@ See [CONTRIBUTING](CONTRIBUTING.md) for information.
 
 `npm install` and then `npm run dev` will get you off the ground for local development. This will start a Docker container for PostgreSQL, but will use a local copy of tsc, webpack, node, etc so you can iterate quickly.
 
-Once things have started up, you can open http://0.0.0.0:8010/webpack-dev-server/. This will automatically reload on browser changes, and the backend will also automatically restart on server-side changes.
+Once things have started up, you can open http://0.0.0.0:2425/webpack-dev-server/. This will automatically reload on browser changes, and the backend will also automatically restart on server-side changes.
 
 Handy environment variables:
 

--- a/browser/app.tsx
+++ b/browser/app.tsx
@@ -1,8 +1,8 @@
 // Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'core-js/shim';
 import 'bootstrap';
+import 'core-js/shim';
 
 import * as React from 'react';
 import { render } from 'react-dom';

--- a/browser/components/projects/editor/DetatchButton.tsx
+++ b/browser/components/projects/editor/DetatchButton.tsx
@@ -51,8 +51,8 @@ export default class DetatchButton extends React.Component<Props, State> {
 
     return (
       <button
-        className={`btn ${className || ''} ${mode ===
-          ConfirmState.Confirm && 'btn-danger'}`}
+        className={`btn ${className || ''} ${mode === ConfirmState.Confirm &&
+          'btn-danger'}`}
         onClick={this.clicked}
         disabled={mode === ConfirmState.Lockout}
       >

--- a/browser/components/projects/editor/PackageFields.tsx
+++ b/browser/components/projects/editor/PackageFields.tsx
@@ -5,7 +5,10 @@ import React = require('react');
 import { connect } from 'react-redux';
 import Select, { Option } from 'react-select';
 
-import { WebLicense, WebTag } from '../../../../server/api/v1/licenses/interfaces';
+import {
+  WebLicense,
+  WebTag,
+} from '../../../../server/api/v1/licenses/interfaces';
 import { WebPackage } from '../../../../server/api/v1/packages/interfaces';
 import * as LicenseActions from '../../../modules/licenses';
 import * as PackageActions from '../../../modules/packages';

--- a/browser/components/projects/editor/questions/SelectWidget.tsx
+++ b/browser/components/projects/editor/questions/SelectWidget.tsx
@@ -12,7 +12,11 @@ export default class SelectWidget extends BaseWidget<BaseProps> {
 
   private renderOption = (opt: [string | number | boolean, string]) => {
     const [optVal, optLabel] = opt;
-    return<option key={optVal.toString()} value={optVal.toString()}>{optLabel}</option>;
+    return (
+      <option key={optVal.toString()} value={optVal.toString()}>
+        {optLabel}
+      </option>
+    );
   };
 
   render() {

--- a/browser/components/projects/editor/refs/ProjectRefInfo.tsx
+++ b/browser/components/projects/editor/refs/ProjectRefInfo.tsx
@@ -6,10 +6,10 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 
 import { WebProject } from '../../../../../server/api/v1/projects/interfaces';
-import * as ProjectActions from '../../../../modules/projects';
-import DetatchButton from '../DetatchButton';
-import { deleteRef } from '../../../../modules/projects';
 import { DbProjectRef } from '../../../../../server/db/projects';
+import * as ProjectActions from '../../../../modules/projects';
+import { deleteRef } from '../../../../modules/projects';
+import DetatchButton from '../DetatchButton';
 
 interface Props {
   project: WebProject & { refInfo: any };

--- a/browser/modules/packages.ts
+++ b/browser/modules/packages.ts
@@ -134,8 +134,8 @@ export function verifyPackage(
  */
 export function fetchVerificationQueue() {
   return dispatch => {
-    return reqJSON('/api/v1/packages/verification', undefined, 'GET').then(json =>
-      dispatch(receiveVerificationQueue(json))
+    return reqJSON('/api/v1/packages/verification', undefined, 'GET').then(
+      json => dispatch(receiveVerificationQueue(json))
     );
   };
 }

--- a/browser/modules/projects.ts
+++ b/browser/modules/projects.ts
@@ -238,7 +238,10 @@ export function cloneProject(
   newDetails: Pick<WebProject, 'title' | 'version' | 'acl'>
 ) {
   return async dispatch => {
-    const json = await reqJSON(`/api/v1/projects/${projectId}/clone`, newDetails);
+    const json = await reqJSON(
+      `/api/v1/projects/${projectId}/clone`,
+      newDetails
+    );
     history.push(`/projects/${json.projectId}`);
   };
 }

--- a/config/dev.js
+++ b/config/dev.js
@@ -4,7 +4,7 @@ const config = base.config;
 
 config.server = {
   hostname: '0.0.0.0',
-  port: 8000,
+  port: 2424,
   contentSecurityPolicy: false,
   cors: true,
 };

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,4 +6,4 @@ services:
     ports:
     - 5432:5432
     volumes:
-    - ./sql:/docker-entrypoint-initdb.d
+    - ./docs/schema.sql:/docker-entrypoint-initdb.d/init.sql

--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -4,7 +4,7 @@ services:
   web:
     build: .
     ports:
-    - 2424:2424
+    - 8000:8000
     links:
     - database
     environment:
@@ -15,7 +15,7 @@ services:
     - ./sql:/docker-entrypoint-initdb.d
   selenium:
     # use standalone-chrome-debug if you want to VNC in and watch
-    image: selenium/standalone-chrome
+    image: selenium/standalone-chrome-debug
     ports:
     - 4444:4444
     - 5900:5900

--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -12,10 +12,10 @@ services:
   database:
     image: postgres
     volumes:
-    - ./sql:/docker-entrypoint-initdb.d
+    - ./docs/schema.sql:/docker-entrypoint-initdb.d/init.sql
   selenium:
     # use standalone-chrome-debug if you want to VNC in and watch
-    image: selenium/standalone-chrome-debug
+    image: selenium/standalone-chrome
     ports:
     - 4444:4444
     - 5900:5900
@@ -24,3 +24,4 @@ services:
     environment:
       SCREEN_WIDTH: 1500
       SCREEN_HEIGHT: 2000
+    shm_size: 2G

--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -4,7 +4,7 @@ services:
   web:
     build: .
     ports:
-    - 8000:8000
+    - 2424:2424
     links:
     - database
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   web:
     build: .
     ports:
-    - 8000:8000
+    - 2424:2424
     links:
     - database
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,4 +12,4 @@ services:
   database:
     image: postgres
     volumes:
-    - ./sql:/docker-entrypoint-initdb.d
+    - ./docs/schema.sql:/docker-entrypoint-initdb.d/init.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   web:
     build: .
     ports:
-    - 2424:2424
+    - 8000:8000
     links:
     - database
     environment:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -141,6 +141,21 @@ components:
         content:
           type: string
 
+    ProjectChangeItem:
+      type: object
+      properties:
+        id:
+          type: number
+        projectId:
+          type: string
+        who:
+          type: string
+        changedOn:
+          type: string
+          format: date-time
+        changedTo:
+          type: object
+
 paths:
   /v1/info:
     get:
@@ -217,14 +232,14 @@ paths:
                 metadata:
                   type: object
             example:
-              title: "My First Project"
-              version: "1.0.0"
-              description: "My project created via the API"
-              plannedRelease: "2099-01-01"
+              title: 'My First Project'
+              version: '1.0.0'
+              description: 'My project created via the API'
+              plannedRelease: '2099-01-01'
               contacts:
-                legal: ["me"]
+                legal: ['me']
               acl:
-                everyone: "owner"
+                everyone: 'owner'
               metadata: {}
 
       responses:
@@ -462,10 +477,10 @@ paths:
                 acl:
                   $ref: '#/components/schemas/ProjectAcl'
             example:
-              title: "My Cloned Project"
-              version: "1.0.0-cloned"
+              title: 'My Cloned Project'
+              version: '1.0.0-cloned'
               acl:
-                everyone: "owner"
+                everyone: 'owner'
 
       responses:
         200:
@@ -477,6 +492,27 @@ paths:
                 properties:
                   projectId:
                     type: string
+
+  /v1/projects/{projectId}/changes:
+    get:
+      summary: list project's change log
+      tags:
+        - projects
+      parameters:
+        - $ref: '#/components/parameters/projectId'
+
+      responses:
+        200:
+          description: A list of all changes made to this project, most recent first. Note that the changedTo field uses database table names, which don't necessarily map 1:1 to the API.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  changes:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ProjectChangeItem'
 
   /v1/packages/:
     post:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -22,6 +22,12 @@ components:
       required: true
       schema:
         type: string
+    documentId:
+      in: path
+      name: documentId
+      required: true
+      schema:
+        type: number
 
   schemas:
     project:
@@ -64,6 +70,43 @@ components:
               type: string
             canEdit:
               type: boolean
+
+    package:
+      type: object
+      properties:
+        packageId:
+          type: string
+        name:
+          type: string
+        version:
+          type: string
+        website:
+          type: string
+        copyright:
+          type: string
+        license:
+          type: string
+        licenseText:
+          type: string
+
+    packageWithUsage:
+      type: object
+
+    attributionDocument:
+      type: object
+      properties:
+        id:
+          type: number
+        projectId:
+          type: string
+        projectVersion:
+          type: string
+        createdOn:
+          type: string
+        createdBy:
+          type: string
+        content:
+          type: string
 
 paths:
   /v1/info:
@@ -126,28 +169,178 @@ paths:
 
     patch:
       summary: edit project details
+      description: Selectively edit primary details of a project. Any fields not included will not be modified.
       parameters:
         - $ref: '#/components/parameters/projectId'
       requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: []
+              properties:
+                title:
+                  type: string
+                  required: false
+                version:
+                  type: string
+                  required: false
+                description:
+                  type: string
+                  required: false
+                plannedRelease:
+                  type: string
+                  required: false
+                contacts:
+                  type: object
+                  required: false
+                acl:
+                  type: object
+                  required: false
+                metadata:
+                  type: object
+                  required: false
+            example:
+              title: 'My new project title'
+      responses:
+        200:
+          description: successfully edited project
+
+  /v1/projects/{projectId}/attach:
+    post:
+      summary: attach a package to the project
+      parameters:
+        - $ref: '#/components/parameters/projectId'
+      requestBody:
+        required: true
         content:
           application/json:
             schema:
               type: object
               properties:
-                title:
+                packageId:
+                  type: string
+                name:
                   type: string
                 version:
                   type: string
-                description:
+                website:
                   type: string
-                plannedRelease:
+                copyright:
                   type: string
-                contacts:
+                license:
+                  type: string
+                licenseText:
+                  type: string
+                usage:
                   type: object
-                acl:
-                  type: object
-                metadata:
-                  type: object
+            examples:
+              add-single-package:
+                summary: add a package by ID only
+                value:
+                  packageId: 12345
+
       responses:
         200:
-          description: successfully edited project
+          description: package was attached
+
+  /v1/projects/{projectId}/build:
+    get:
+      summary: preview attribution document and annotations
+      parameters:
+        - $ref: '#/components/parameters/projectId'
+
+      responses:
+        200:
+          description: attribution document preview and annotations
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  text:
+                    type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object # TODO
+                      properties:
+                        lines:
+                          type: array
+                          minItems: 2
+                          maxItems: 2
+                        type:
+                          type: string
+                  summary:
+                    type: object
+
+    post:
+      summary: generate and store attribution document
+      parameters:
+        - $ref: '#/components/parameters/projectId'
+
+      responses:
+        200:
+          description: attribution document preview and annotations
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  text:
+                    type: string
+                  documentId:
+                    type: number
+
+  /v1/projects/{projectId}/docs:
+    get:
+      summary: list project's stored attribution documents
+      parameters:
+        - $ref: '#/components/parameters/projectId'
+
+      responses:
+        200:
+          description: a list of all attribution documents attached to this project
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  documents:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: number
+                        projectVersion:
+                          type: string
+                        createdOn:
+                          type: string
+                        createdBy:
+                          type: string
+
+  /v1/projects/{projectId}/docs/{documentId}:
+    get:
+      summary: fetch a rendered attribution document
+      description: Fetches an attribution document attached to a project. Includes information about when the document was created; a plain-text-only version can be fetched by appending `.text` to the end of the URL.
+      parameters:
+        - $ref: '#/components/parameters/projectId'
+        - $ref: '#/components/parameters/documentId'
+
+      responses:
+        200:
+          description: a rendered attribution document with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/attributionDocument'
+
+  /v1/packages/:
+    post:
+      summary: search packages
+
+      responses:
+        200:
+          description: search results

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5,10 +5,19 @@ info:
   title: 'oss-attribution-builder API'
   version: '1.0.0'
 servers:
+  - url: '/api/'
   - url: 'http://localhost:2424/api/'
 security:
   - nullauth: []
   - cookie: []
+
+tags:
+  - name: projects
+    description: Project management actions
+  - name: attribution documents
+    description: Attribution documents (contained within projects)
+  - name: packages
+    description: Package information
 
 components:
   securitySchemes:
@@ -159,6 +168,8 @@ paths:
   /v1/projects:
     get:
       summary: get all accessible projects
+      tags:
+        - projects
       responses:
         200:
           description: list of projects
@@ -181,6 +192,8 @@ paths:
   /v1/projects/new:
     post:
       summary: create a new project
+      tags:
+        - projects
 
       requestBody:
         required: true
@@ -228,6 +241,8 @@ paths:
   /v1/projects/{projectId}:
     get:
       summary: get project by id
+      tags:
+        - projects
       parameters:
         - $ref: '#/components/parameters/projectId'
       responses:
@@ -241,6 +256,8 @@ paths:
     patch:
       summary: edit project details
       description: Selectively edit primary details of a project. Any fields not included will not be modified.
+      tags:
+        - projects
       parameters:
         - $ref: '#/components/parameters/projectId'
       requestBody:
@@ -281,6 +298,9 @@ paths:
   /v1/projects/{projectId}/attach:
     post:
       summary: attach a package to the project
+      tags:
+        - projects
+        - packages
       parameters:
         - $ref: '#/components/parameters/projectId'
       requestBody:
@@ -319,6 +339,8 @@ paths:
   /v1/projects/{projectId}/build:
     get:
       summary: preview attribution document and annotations
+      tags:
+        - projects
       parameters:
         - $ref: '#/components/parameters/projectId'
 
@@ -348,6 +370,9 @@ paths:
 
     post:
       summary: generate and store attribution document
+      tags:
+        - projects
+        - attribution documents
       parameters:
         - $ref: '#/components/parameters/projectId'
 
@@ -367,6 +392,9 @@ paths:
   /v1/projects/{projectId}/docs:
     get:
       summary: list project's stored attribution documents
+      tags:
+        - projects
+        - attribution documents
       parameters:
         - $ref: '#/components/parameters/projectId'
 
@@ -396,6 +424,9 @@ paths:
     get:
       summary: fetch a rendered attribution document
       description: Fetches an attribution document attached to a project. Includes information about when the document was created; a plain-text-only version can be fetched by appending `.text` to the end of the URL.
+      tags:
+        - projects
+        - attribution documents
       parameters:
         - $ref: '#/components/parameters/projectId'
         - $ref: '#/components/parameters/documentId'
@@ -412,6 +443,8 @@ paths:
     post:
       summary: clone a project
       description: Clone a project. Can clone any project you can view. The title, version, and ACL can all be changed with this call. Your ACL must specify an owning group that you are a member of.
+      tags:
+        - projects
       parameters:
         - $ref: '#/components/parameters/projectId'
 
@@ -448,6 +481,8 @@ paths:
   /v1/packages/:
     post:
       summary: search packages
+      tags:
+        - packages
 
       requestBody:
         required: true
@@ -475,6 +510,8 @@ paths:
   /v1/packages/{packageId}:
     get:
       summary: get a single package
+      tags:
+        - packages
 
       parameters:
         - $ref: '#/components/parameters/packageId'

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5,15 +5,21 @@ info:
   title: 'oss-attribution-builder API'
   version: '1.0.0'
 servers:
-  - url: 'http://localhost:8000/api/'
+  - url: 'http://localhost:2424/api/'
 security:
   - nullauth: []
+  - cookie: []
 
 components:
   securitySchemes:
     nullauth:
       type: http
       scheme: basic
+      description: Dummy authentication for the demo site. Use any username and password.
+
+    cookie:
+      type: apiKey
+      in: cookie
 
   parameters:
     projectId:
@@ -28,9 +34,15 @@ components:
       required: true
       schema:
         type: number
+    packageId:
+      in: path
+      name: packageId
+      required: true
+      schema:
+        type: number
 
   schemas:
-    project:
+    Project:
       type: object
       properties:
         projectId:
@@ -45,24 +57,18 @@ components:
           type: string
         plannedRelease:
           type: string
+          format: date
         contacts:
-          type: object
-          additionalProperties:
-            type: array
-            items:
-              type: string
+          $ref: '#/components/schemas/ProjectContacts'
         acl:
-          type: object
-          additionalProperties:
-            type: string
+          $ref: '#/components/schemas/ProjectAcl'
         packagesUsed:
           type: array
           items:
             type: object
         refs:
           type: object
-        metadata:
-          type: object
+        metadata: {}
         access:
           type: object
           properties:
@@ -71,7 +77,25 @@ components:
             canEdit:
               type: boolean
 
-    package:
+    ProjectAcl:
+      type: object
+      additionalProperties:
+        type: string
+        enum:
+          - owner
+          - editor
+          - viewer
+
+    ProjectContacts:
+      type: object
+      additionalProperties:
+        type: array
+        items:
+          type: array
+          items:
+            type: string
+
+    Package:
       type: object
       properties:
         packageId:
@@ -89,10 +113,10 @@ components:
         licenseText:
           type: string
 
-    packageWithUsage:
+    PackageWithUsage:
       type: object
 
-    attributionDocument:
+    AttributionDocument:
       type: object
       properties:
         id:
@@ -154,6 +178,53 @@ paths:
                     createdOn:
                       type: string
 
+  /v1/projects/new:
+    post:
+      summary: create a new project
+
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                version:
+                  type: string
+                description:
+                  type: string
+                plannedRelease:
+                  type: string
+                contacts:
+                  $ref: '#/components/schemas/ProjectContacts'
+                acl:
+                  $ref: '#/components/schemas/ProjectAcl'
+                metadata:
+                  type: object
+            example:
+              title: "My First Project"
+              version: "1.0.0"
+              description: "My project created via the API"
+              plannedRelease: "2099-01-01"
+              contacts:
+                legal: ["me"]
+              acl:
+                everyone: "owner"
+              metadata: {}
+
+      responses:
+        200:
+          description: project created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  projectId:
+                    type: string
+
   /v1/projects/{projectId}:
     get:
       summary: get project by id
@@ -165,7 +236,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/project'
+                $ref: '#/components/schemas/Project'
 
     patch:
       summary: edit project details
@@ -335,12 +406,83 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/attributionDocument'
+                $ref: '#/components/schemas/AttributionDocument'
+
+  /v1/projects/{projectId}/clone:
+    post:
+      summary: clone a project
+      description: Clone a project. Can clone any project you can view. The title, version, and ACL can all be changed with this call. Your ACL must specify an owning group that you are a member of.
+      parameters:
+        - $ref: '#/components/parameters/projectId'
+
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                version:
+                  type: string
+                acl:
+                  $ref: '#/components/schemas/ProjectAcl'
+            example:
+              title: "My Cloned Project"
+              version: "1.0.0-cloned"
+              acl:
+                everyone: "owner"
+
+      responses:
+        200:
+          description: project cloned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  projectId:
+                    type: string
 
   /v1/packages/:
     post:
       summary: search packages
 
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                query:
+                  type: string
+
       responses:
         200:
           description: search results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Package'
+
+  /v1/packages/{packageId}:
+    get:
+      summary: get a single package
+
+      parameters:
+        - $ref: '#/components/parameters/packageId'
+
+      responses:
+        200:
+          description: content of package
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Package'

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -1,4 +1,6 @@
-CREATE TABLE projects
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE TABLE IF NOT EXISTS projects
 (
   project_id TEXT PRIMARY KEY NOT NULL,
   title TEXT NOT NULL,
@@ -12,10 +14,10 @@ CREATE TABLE projects
   refs JSONB NOT NULL DEFAULT '{}',
   metadata JSONB
 );
-CREATE INDEX projects_packages_used_gin ON projects USING GIN (packages_used jsonb_path_ops);
-CREATE INDEX projects_refs_gin ON projects USING GIN (refs);
+CREATE INDEX IF NOT EXISTS projects_packages_used_gin ON projects USING GIN (packages_used jsonb_path_ops);
+CREATE INDEX IF NOT EXISTS projects_refs_gin ON projects USING GIN (refs);
 
-CREATE TABLE attribution_documents
+CREATE TABLE IF NOT EXISTS attribution_documents
 (
   doc_id SERIAL PRIMARY KEY NOT NULL,
   project_id TEXT NOT NULL,
@@ -26,7 +28,7 @@ CREATE TABLE attribution_documents
   CONSTRAINT attribution_documents_projects_project_id_fk FOREIGN KEY (project_id) REFERENCES projects (project_id)
 );
 
-CREATE TABLE packages
+CREATE TABLE IF NOT EXISTS packages
 (
   package_id SERIAL PRIMARY KEY NOT NULL,
   name TEXT NOT NULL,
@@ -38,9 +40,9 @@ CREATE TABLE packages
   created_by TEXT,
   verified BOOLEAN -- null: unverified, true: verified good, false: verified bad
 );
-CREATE INDEX packages_name_version_package_id_index ON packages USING BTREE (name, version, package_id);
+CREATE INDEX IF NOT EXISTS packages_name_version_package_id_index ON packages USING BTREE (name, version, package_id);
 
-CREATE TABLE packages_verify
+CREATE TABLE IF NOT EXISTS packages_verify
 (
   id SERIAL PRIMARY KEY NOT NULL,
   package_id INTEGER NOT NULL,
@@ -49,9 +51,9 @@ CREATE TABLE packages_verify
   comments TEXT,
   CONSTRAINT packages_verify_packages_package_id_fk FOREIGN KEY (package_id) REFERENCES packages (package_id)
 );
-CREATE INDEX packages_verify_package_id_index ON packages_verify (package_id);
+CREATE INDEX IF NOT EXISTS packages_verify_package_id_index ON packages_verify (package_id);
 
-CREATE TABLE projects_audit
+CREATE TABLE IF NOT EXISTS projects_audit
 (
   id SERIAL PRIMARY KEY NOT NULL,
   project_id TEXT NOT NULL,

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS packages
   verified BOOLEAN -- null: unverified, true: verified good, false: verified bad
 );
 CREATE INDEX IF NOT EXISTS packages_name_version_package_id_index ON packages USING BTREE (name, version, package_id);
+CREATE INDEX IF NOT EXISTS packages_name_version_tsv_index ON PACKAGES USING GIN (to_tsvector);
 
 CREATE TABLE IF NOT EXISTS packages_verify
 (

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS packages
   verified BOOLEAN -- null: unverified, true: verified good, false: verified bad
 );
 CREATE INDEX IF NOT EXISTS packages_name_version_package_id_index ON packages USING BTREE (name, version, package_id);
-CREATE INDEX IF NOT EXISTS packages_name_version_tsv_index ON PACKAGES USING GIN (to_tsvector);
+CREATE INDEX IF NOT EXISTS packages_name_version_tsv_index ON packages USING GIN (to_tsvector('english', name || ' ' || version));
 
 CREATE TABLE IF NOT EXISTS packages_verify
 (

--- a/package-lock.json
+++ b/package-lock.json
@@ -4914,24 +4914,6 @@
       "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc=",
       "dev": true
     },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-      "dev": true
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
-    },
-    "lodash.mergewith": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
-      "dev": true
-    },
     "lodash.tail": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
@@ -5422,9 +5404,9 @@
       }
     },
     "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
       "dev": true
     },
     "nanomatch": {
@@ -5553,9 +5535,9 @@
       }
     },
     "node-sass": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
-      "integrity": "sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz",
+      "integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -5565,12 +5547,10 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash.assign": "^4.2.0",
-        "lodash.clonedeep": "^4.3.2",
-        "lodash.mergewith": "^4.6.0",
+        "lodash": "^4.17.11",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
-        "nan": "^2.10.0",
+        "nan": "^2.13.2",
         "node-gyp": "^3.8.0",
         "npmlog": "^4.0.0",
         "request": "^2.88.0",
@@ -5708,9 +5688,9 @@
           "dev": true
         },
         "resolve": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
+          "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
           "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
@@ -7025,18 +7005,18 @@
       },
       "dependencies": {
         "mime-db": {
-          "version": "1.38.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-          "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+          "version": "1.40.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+          "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
           "dev": true
         },
         "mime-types": {
-          "version": "2.1.22",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
-          "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+          "version": "2.1.24",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+          "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
           "dev": true,
           "requires": {
-            "mime-db": "~1.38.0"
+            "mime-db": "1.40.0"
           }
         },
         "safe-buffer": {
@@ -7707,9 +7687,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
-      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
       "dev": true
     },
     "spdx-license-list": {
@@ -8120,6 +8100,19 @@
       "dev": true,
       "requires": {
         "has-flag": "^1.0.0"
+      }
+    },
+    "swagger-ui-dist": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.22.1.tgz",
+      "integrity": "sha512-KITbEqXkXrjGH12A0lpVZlH3uODFkwUh8d15My1YD4N0PSZDnIiC1iMFT6ryyuJxDYWZh0qezKpPqa5FRowngw=="
+    },
+    "swagger-ui-express": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.0.2.tgz",
+      "integrity": "sha512-XZtXI2+SKT3fgvJSGg4P7Dtmkzr50uoSb09IxbUWmjL538TIGRMZtfdEkjZEEq44xgGNAxMryzBEUdUnkXr8dA==",
+      "requires": {
+        "swagger-ui-dist": "^3.18.1"
       }
     },
     "symbol-observable": {
@@ -10097,6 +10090,16 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "yamljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
+      "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "glob": "^7.0.5"
+      }
     },
     "yargs": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "main": "server/app.js",
   "scripts": {
-    "build": "tsc && webpack && npm run copy-static",
-    "copy-static": "mkdir -p build/server && cp -r config build && cp -r assets build/server",
+    "build": "tsc && webpack && npm run static",
+    "static": "mkdir -p build/server && cp -r config build && cp -r assets build/server && yaml2json docs/openapi.yaml > build/server/api/openapi.json",
     "dev": "export NODE_ENV=development CONFIG_NAME=dev && npm run build && concurrently -k \"docker-compose -f docker-compose.dev.yml up\" \"tsc -w\" \"nodemon -d 1 -w build build/server/localserver.js\" \"webpack-dev-server\"",
     "start": "export NODE_ENV=production && npm run build && node ./build/server/localserver.js",
     "test": "npm run build && jasmine 'build/server/**/*.spec.js'",
@@ -53,7 +53,7 @@
     "jquery": "^3.4.0",
     "mini-css-extract-plugin": "^0.5.0",
     "mockery": "^2.1.0",
-    "node-sass": "^4.11.0",
+    "node-sass": "^4.12.0",
     "nodemon": "^1.17.4",
     "pg-monitor": "^0.8.5",
     "popper.js": "^1.14.3",
@@ -74,7 +74,8 @@
     "url-loader": "^1.1.2",
     "webpack": "^4.29.0",
     "webpack-cli": "^3.2.3",
-    "webpack-dev-server": "^3.1.14"
+    "webpack-dev-server": "^3.1.14",
+    "yamljs": "^0.3.0"
   },
   "dependencies": {
     "compression": "^1.7.2",
@@ -89,6 +90,7 @@
     "pg-promise": "^6.3.8",
     "source-map-support": "^0.4.0",
     "spdx-license-list": "^4.1.0",
+    "swagger-ui-express": "^4.0.2",
     "tiny-attribution-generator": "^0.1.1",
     "uuid": "^3.3.2",
     "whatwg-fetch": "^2.0.4",

--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as express from 'express';
-import * as winston from 'winston';
 import * as swaggerUi from 'swagger-ui-express';
+import * as winston from 'winston';
 
-import v1Router from './routes-v1';
 import config from '../config';
+import v1Router from './routes-v1';
 
 export let router = express.Router();
 router.use(express.json({ limit: config.server.maxRequestSize }));
@@ -15,9 +15,14 @@ router.use(express.json({ limit: config.server.maxRequestSize }));
 router.use('/v1', v1Router);
 
 // api docs
-router.use('/docs', swaggerUi.serve, swaggerUi.setup(require('./openapi.json'), {
-  customCss: '.swagger-ui .topbar { display: none }'
-}));
+router.use(
+  '/docs',
+  swaggerUi.serve,
+  // tslint:disable-next-line:no-var-requires
+  swaggerUi.setup(require('./openapi.json'), {
+    customCss: '.swagger-ui .topbar { display: none }',
+  })
+);
 
 // unprefixed v1 routes
 router.use((req, res, next) => {

--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -3,6 +3,7 @@
 
 import * as express from 'express';
 import * as winston from 'winston';
+import * as swaggerUi from 'swagger-ui-express';
 
 import v1Router from './routes-v1';
 import config from '../config';
@@ -12,6 +13,11 @@ router.use(express.json({ limit: config.server.maxRequestSize }));
 
 // actual APIs are versioned
 router.use('/v1', v1Router);
+
+// api docs
+router.use('/docs', swaggerUi.serve, swaggerUi.setup(require('./openapi.json'), {
+  customCss: '.swagger-ui .topbar { display: none }'
+});
 
 // unprefixed v1 routes
 router.use((req, res, next) => {

--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -17,7 +17,7 @@ router.use('/v1', v1Router);
 // api docs
 router.use('/docs', swaggerUi.serve, swaggerUi.setup(require('./openapi.json'), {
   customCss: '.swagger-ui .topbar { display: none }'
-});
+}));
 
 // unprefixed v1 routes
 router.use((req, res, next) => {

--- a/server/api/v1/projects/attribution.ts
+++ b/server/api/v1/projects/attribution.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import DocBuilder, {
-  Package as TagPackage,
-  NamedLicense,
   LicenseBucket,
   LicenseDictionary,
+  NamedLicense,
+  Package as TagPackage,
 } from 'tiny-attribution-generator';
 import uuidv5 = require('uuid/v5');
 

--- a/server/api/v1/projects/index.ts
+++ b/server/api/v1/projects/index.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as express from 'express';
-import * as winston from 'winston';
 import DocBuilder from 'tiny-attribution-generator';
 import TextRenderer from 'tiny-attribution-generator/lib/outputs/text';
+import * as winston from 'winston';
 
 import auth from '../../../auth';
 import { isAdmin } from '../../../auth/util';
@@ -17,10 +17,10 @@ import { asyncApi } from '../../../util/middleware';
 import { storePackage } from '../packages';
 import {
   addProjectPackages,
+  applyCopyrightTransforms,
+  applyTextTransforms,
   getWarnings,
   OverlayLicenseDictionary,
-  applyTextTransforms,
-  applyCopyrightTransforms,
 } from './attribution';
 import {
   assertProjectAccess,
@@ -600,7 +600,7 @@ export async function deleteRef(
     ...project.refs,
   };
   delete refs[targetProjectId];
-  db.patchProject(projectId, { refs }, user);
+  await db.patchProject(projectId, { refs }, user);
 
   return { projectId };
 }

--- a/server/api/v1/projects/index.ts
+++ b/server/api/v1/projects/index.ts
@@ -11,6 +11,7 @@ import { isAdmin } from '../../../auth/util';
 import * as documentdb from '../../../db/attribution_documents';
 import * as db from '../../../db/projects';
 import { DbPackageUsage } from '../../../db/projects';
+import { getProjectAuditLog } from '../../../db/projects_audit';
 import { AccessError } from '../../../errors/index';
 import { asyncApi } from '../../../util/middleware';
 import { storePackage } from '../packages';
@@ -602,4 +603,28 @@ export async function deleteRef(
   db.patchProject(projectId, { refs }, user);
 
   return { projectId };
+}
+
+/**
+ * Fetch the project's audit log.
+ */
+router.get(
+  '/:projectId/changes',
+  requireProjectAccess('viewer'),
+  asyncApi(listProjectChanges)
+);
+export async function listProjectChanges(
+  req: express.Request,
+  res: express.Response
+) {
+  const changes = await getProjectAuditLog(req.params.projectId);
+  return {
+    changes: changes.map(c => ({
+      id: c.id,
+      projectId: c.project_id,
+      who: c.who,
+      changedOn: c.changed_on,
+      changedTo: c.changed_to,
+    })),
+  };
 }

--- a/server/api/v1/projects/validators.ts
+++ b/server/api/v1/projects/validators.ts
@@ -65,6 +65,9 @@ export async function patchProject(req, res, next) {
 }
 
 async function validateContacts(contacts) {
+  if (contacts.legal == undefined) {
+    throw new RequestError('Missing legal contact');
+  }
   for (const contactType of Object.keys(contacts)) {
     for (const contact of contacts[contactType]) {
       const n = await auth.getDisplayName(contact);

--- a/server/db/attribution_documents.ts
+++ b/server/db/attribution_documents.ts
@@ -24,7 +24,14 @@ export function getAttributionDocument(
 
 export function findDocumentsForProject(
   projectId: string
-): Promise<Pick<AttributionDocument, 'doc_id' | 'project_version' | 'created_on' | 'created_by'>[]> {
+): Promise<
+  Array<
+    Pick<
+      AttributionDocument,
+      'doc_id' | 'project_version' | 'created_on' | 'created_by'
+    >
+  >
+> {
   return pg().query(
     'select doc_id, project_version, created_on, created_by from attribution_documents where project_id = $1 order by created_on desc',
     [projectId]

--- a/server/db/packages.ts
+++ b/server/db/packages.ts
@@ -42,7 +42,7 @@ export function searchPackages(
   // only fetch the latest revision of each package
   return pg().query(
     `select distinct on (name, version) * from (` +
-      `select name, version, package_id from packages ` +
+      `select * from packages ` +
       `where to_tsvector(name || ' ' || version) @@ to_tsquery($1)` +
       `) as search order by name, version, package_id desc limit $2`,
     [tsquery, limit]

--- a/server/db/packages.ts
+++ b/server/db/packages.ts
@@ -1,4 +1,4 @@
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import pg from './index';
@@ -27,10 +27,25 @@ export function searchPackages(
   search: string,
   limit: number
 ): Promise<Package[]> {
+  // build up a sanitized postgresql fulltext tsquery
+  // remove junk, split on space, add quotes + wildcard, then join with &
+  const tsquery = search
+    .trim()
+    .replace(/[^\w\s]+/u, '')
+    .split(/\s+/u)
+    .map(t => `'${t}':*`)
+    .join(' & ');
+
+  // two queries here:
+  // the inner query is actually running the full-text search (to take
+  // advantage of an index), and the outer performs a distinct query to
+  // only fetch the latest revision of each package
   return pg().query(
-    'select distinct on (name, version) * from packages ' +
-      'where name ilike $1 order by name, version, package_id desc limit $2',
-    [`%${search}%`, limit]
+    `select distinct on (name, version) * from (` +
+      `select name, version, package_id from packages ` +
+      `where to_tsvector(name || ' ' || version) @@ to_tsquery($1)` +
+      `) as search order by name, version, package_id desc limit $2`,
+    [tsquery, limit]
   );
 }
 

--- a/server/db/packages.ts
+++ b/server/db/packages.ts
@@ -43,7 +43,7 @@ export function searchPackages(
   return pg().query(
     `select distinct on (name, version) * from (` +
       `select * from packages ` +
-      `where to_tsvector(name || ' ' || version) @@ to_tsquery($1)` +
+      `where to_tsvector('english', name || ' ' || version) @@ to_tsquery($1)` +
       `) as search order by name, version, package_id desc limit $2`,
     [tsquery, limit]
   );

--- a/server/licenses/tags/notice.ts
+++ b/server/licenses/tags/notice.ts
@@ -6,7 +6,7 @@
 // largely Apache-2.0 specific.
 
 // we strip out the original copyright text up top
-export function transformCopyright(_original) {
+export function transformCopyright(original) {
   return '';
 }
 

--- a/server/licenses/tags/spdx.ts
+++ b/server/licenses/tags/spdx.ts
@@ -3,7 +3,7 @@
 
 // This tag notes that the license was pulled from SPDX sources.
 
-export function transformLicense(original, _packages) {
+export function transformLicense(original, packages) {
   let text = original;
 
   // SPDX BSD texts include a stub copyright line for some reason. remove those.

--- a/server/licenses/tags/validation-demo.ts
+++ b/server/licenses/tags/validation-demo.ts
@@ -16,8 +16,9 @@ export function validateUsage(pkg, usage) {
     return [
       {
         level: 1,
-        message:
-          `This is a demo validation warning because you selected "Yes" to causing warnings on a package ("${pkg.name}") with MyCustomLicense (or another license with the "validation-demo" tag. Click it to highlight the package below!`,
+        message: `This is a demo validation warning because you selected "Yes" to causing warnings on a package ("${
+          pkg.name
+        }") with MyCustomLicense (or another license with the "validation-demo" tag. Click it to highlight the package below!`,
       },
     ];
   }

--- a/spec/selenium/driver.ts
+++ b/spec/selenium/driver.ts
@@ -17,7 +17,7 @@ export default async function(): Promise<CustomDriver> {
     .forBrowser('chrome')
     .build();
   driver.getRelative = function(path: string) {
-    return driver.get(`http://web:2424${path}`);
+    return driver.get(`http://web:8000${path}`);
   };
   driver.setUser = async function(user: string = 'selenium') {
     driver.getRelative('/dummy-no-auth');

--- a/spec/selenium/driver.ts
+++ b/spec/selenium/driver.ts
@@ -17,7 +17,7 @@ export default async function(): Promise<CustomDriver> {
     .forBrowser('chrome')
     .build();
   driver.getRelative = function(path: string) {
-    return driver.get(`http://web:8000${path}`);
+    return driver.get(`http://web:2424${path}`);
   };
   driver.setUser = async function(user: string = 'selenium') {
     driver.getRelative('/dummy-no-auth');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,10 +67,10 @@ module.exports = {
   plugins,
 
   devServer: {
-    port: 8010,
+    port: 2425,
     publicPath: '/res/',
     proxy: {
-      '*': 'http://localhost:8000',
+      '*': 'http://localhost:2424',
     },
     stats: 'minimal',
   },


### PR DESCRIPTION
This PR adds a documented API covering most of oss-a-b's functionality. More will be added over time. It uses OAS 3.0 / Swagger definitions; see docs/openapi.yaml. This is converted at build time and loaded onto the server for an interactive browser at `/api/docs`.

Some other fresh changes snuck in here, as well. Package search was improved to use a full-text search index, making that much more flexible. Endpoints for viewing attribution documents and audit logs were added, although these are not present in the UI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
